### PR TITLE
Document processed folder overrides for shallow Zarr

### DIFF
--- a/docs/developer/biomero-shallow-zarr.md
+++ b/docs/developer/biomero-shallow-zarr.md
@@ -110,6 +110,13 @@ scientific object.
 | OMERO label Image | OMERO metadata plus PixelBuffer path | A view of one label node, not another copy of the whole collection | iViewer, thumbnails, ROI conversion, and user selection |
 | Reconstructed follow-up input | Temporary transfer directory | Source pixels plus all inherited and local labels, materialized as one conventional Zarr | The next Zarr-native workflow |
 
+```{note}
+The `.processed` default can be changed with `PROCESSED_DATA_FOLDER` in the
+Python process creating canonical Zarrs, using an importer release that supports
+this option. For OMERO scripts, forward it through the worker's script
+environment. Existing stored paths are not migrated.
+```
+
 The stored shallow directory is therefore often **not byte-for-byte the Zarr
 that the workflow received**. It is the compact, authoritative result in
 BIOMERO-managed storage. At the workflow boundary BIOMERO turns it back into a

--- a/docs/developer/biomero-shallow-zarr.md
+++ b/docs/developer/biomero-shallow-zarr.md
@@ -111,10 +111,12 @@ scientific object.
 | Reconstructed follow-up input | Temporary transfer directory | Source pixels plus all inherited and local labels, materialized as one conventional Zarr | The next Zarr-native workflow |
 
 ```{note}
-The `.processed` default can be changed with `PROCESSED_DATA_FOLDER` in the
-Python process creating canonical Zarrs, using an importer release that supports
-this option. For OMERO scripts, forward it through the worker's script
-environment. Existing stored paths are not migrated.
+`PROCESSED_DATA_FOLDER` is an importer-library setting (default `.processed`).
+Set it on the importer container to change preprocessing output. Image Transfer
+also calls the importer's `CanonicalStore` inside the worker; only pass the
+variable through to that script if its canonical exports should use the custom
+folder too. Both uses require an importer release supporting the option.
+Existing stored paths are not migrated.
 ```
 
 The stored shallow directory is therefore often **not byte-for-byte the Zarr

--- a/docs/developer/biomero-shallow-zarr.md
+++ b/docs/developer/biomero-shallow-zarr.md
@@ -112,11 +112,14 @@ scientific object.
 
 ```{note}
 `PROCESSED_DATA_FOLDER` is an importer-library setting (default `.processed`).
-Set it on the importer container to change preprocessing output. Image Transfer
-also calls the importer's `CanonicalStore` inside the worker; only pass the
-variable through to that script if its canonical exports should use the custom
-folder too. Both uses require an importer release supporting the option.
-Existing stored paths are not migrated.
+Set it on the importer container to change preprocessing output. With
+`BIOMERO_SHALLOW_ZARR=true` and a custom folder, also set the same value on
+`biomeroworker`: Image Transfer calls the importer's `CanonicalStore` there to
+choose destinations for new canonical Zarr copies. The processor forwards the
+name automatically from `biomero.constants.slurm_env`; the worker needs BIOMERO
+and importer versions supporting this option. With shallow-Zarr disabled, no
+worker setting is needed. Existing locations are read from stored metadata and
+are not migrated when this value changes.
 ```
 
 The stored shallow directory is therefore often **not byte-for-byte the Zarr

--- a/docs/developer/containers/biomero-importer.rst
+++ b/docs/developer/containers/biomero-importer.rst
@@ -56,6 +56,14 @@ File system monitoring and processing
 - All imports are in-place. OMERO.server must mount the same storage at the same path for symlink-based imports to work.
 - For large/long imports, enable preprocessing: after preprocessing BIOMERO.importer imports from local temporary storage on OMERO.server, then redirects symlinks to the network location afterward. This reduces network risk during in-place import.
 
+.. note::
+
+   ``.processed`` is the default subfolder name. With an importer release that
+   supports this option, set ``PROCESSED_DATA_FOLDER`` in the importer container's
+   environment (for example, ``PROCESSED_DATA_FOLDER=.import``) to change it.
+   The value is used as supplied. Existing data is not migrated; keep its original
+   paths accessible to OMERO.
+
 Configuration
 -------------
 

--- a/docs/developer/containers/biomero-importer.rst
+++ b/docs/developer/containers/biomero-importer.rst
@@ -64,6 +64,12 @@ File system monitoring and processing
    The value is used as supplied. Existing data is not migrated; keep its original
    paths accessible to OMERO.
 
+   If ``BIOMERO_SHALLOW_ZARR=true`` and you use a custom folder, also set the same
+   value on ``biomeroworker`` for new canonical Zarr copies. Its processor forwards
+   the name from ``biomero.constants.slurm_env``; the worker needs BIOMERO and
+   importer versions supporting this option. With shallow-Zarr disabled, only
+   the importer container needs the value.
+
 Configuration
 -------------
 

--- a/docs/sysadmin/analyzer-importer-admin.rst
+++ b/docs/sysadmin/analyzer-importer-admin.rst
@@ -119,6 +119,10 @@ The three containers below must all mount the same storage at the **same contain
    :doc:`../developer/containers/biomero-importer` for details. This does not
    change the separate ``.analyzed`` results folder.
 
+   For a custom folder with ``BIOMERO_SHALLOW_ZARR=true``, also set the same value
+   on ``biomeroworker`` so new canonical Zarr copies use that folder. No worker
+   setting is needed when shallow-Zarr is disabled.
+
 Result folder structure
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/sysadmin/analyzer-importer-admin.rst
+++ b/docs/sysadmin/analyzer-importer-admin.rst
@@ -111,6 +111,14 @@ The three containers below must all mount the same storage at the **same contain
      - Resolves symlinks after in-place import
      - ``./web/L-Drive:/data``
 
+.. note::
+
+   The ``.processed`` subfolder name can be changed with the
+   ``PROCESSED_DATA_FOLDER`` environment variable in the importer container;
+   leaving it unset preserves the default. See
+   :doc:`../developer/containers/biomero-importer` for details. This does not
+   change the separate ``.analyzed`` results folder.
+
 Result folder structure
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The importer container, analyzer/importer administration, and shallow-Zarr documentation describe `.processed` without explaining its runtime override. Add short notes for `PROCESSED_DATA_FOLDER`, retaining `.processed` when unset and explaining that existing data is not migrated.

For a custom folder with `BIOMERO_SHALLOW_ZARR=true`, document that `biomeroworker` needs the same value for new canonical copies. Its processor obtains the variable name from BIOMERO's shared `slurm_env` constants. With shallow-Zarr disabled, only the importer container needs the setting. Existing canonical locations are read from metadata.

Validation: Sphinx HTML build completed and the notes render in all three pages; remaining warnings were outside those pages. `git diff --check` passed.

Companion hotpatch: https://github.com/NL-BioImaging/biomero/pull/37

Please squash merge after review and CI.
